### PR TITLE
Add FastAPI proxy server for CAST AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# CastAI-MCP
-CastAI-MCP
+# CastAI MCP Proxy Server
+
+This repository contains a small FastAPI server that proxies requests to the [CAST AI API](https://api.eu.cast.ai). The server exposes the same OpenAPI schema available at `https://api.eu.cast.ai/v1/spec/preview/openapi.json` and forwards all incoming requests to the remote API.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the server:
+
+```bash
+uvicorn main:app --reload
+```
+
+You can then send requests to `http://localhost:8000/...` and they will be proxied to `https://api.eu.cast.ai/...`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,28 @@
+import httpx
+from fastapi import FastAPI, Request, Response
+
+SPEC_URL = "https://api.eu.cast.ai/v1/spec/preview/openapi.json"
+API_BASE = "https://api.eu.cast.ai"
+
+app = FastAPI(title="CastAI MCP Proxy")
+
+@app.get("/openapi.json")
+async def get_spec():
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(SPEC_URL)
+    return Response(content=resp.content, media_type="application/json")
+
+async def proxy(request: Request, full_path: str):
+    method = request.method
+    headers = dict(request.headers)
+    headers.pop("host", None)
+    params = dict(request.query_params)
+    body = await request.body()
+
+    async with httpx.AsyncClient(base_url=API_BASE) as client:
+        resp = await client.request(method, f"/{full_path}", params=params, content=body, headers=headers)
+    return Response(content=resp.content, status_code=resp.status_code, headers={"content-type": resp.headers.get("content-type", "application/json")})
+
+# Capture all paths
+for method in ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]:
+    app.add_api_route("/{full_path:path}", proxy, methods=[method])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx


### PR DESCRIPTION
## Summary
- create a minimal FastAPI server that proxies CAST AI API requests
- add requirements
- update README with usage instructions

## Testing
- `pip install -r requirements.txt --quiet`
- `python - <<'EOF'
import uvicorn
import threading
from main import app
server = threading.Thread(target=uvicorn.run, args=(app,), kwargs={"host":"0.0.0.0","port":8000,"log_level":"info"}, daemon=True)
server.start()
import time
print("server started")
time.sleep(2)
print("stop")
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684a862dfda483238dcc551eb61d66ee