### PR TITLE
Add CI pipeline and Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt pytest
+      - name: Run tests
+        run: |
+          PYTHONPATH=. pytest -q
+      - name: Build Docker image
+        run: |
+          docker build -t castai-mcp .
+      - name: Run container
+        run: |
+          docker run -d --name castai -p 8000:8000 castai-mcp
+          sleep 5
+          curl -f http://localhost:8000/openapi.json | head -c 20
+          docker stop castai
+          docker rm castai

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile for running the FastAPI server
- add GitHub Actions workflow that runs tests, builds a Docker image and starts the container

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8b3834908323b541f1e8709d5163